### PR TITLE
Add standalone script compiler CLI

### DIFF
--- a/ScriptCompiler/Program.cs
+++ b/ScriptCompiler/Program.cs
@@ -1,0 +1,42 @@
+using System;
+using System.IO;
+using System.Reflection;
+using Server;
+
+namespace ScriptCompilerCli
+{
+    internal static class Program
+    {
+        private static int Main(string[] args)
+        {
+            var debug = false;
+            var cache = true;
+
+            foreach (var arg in args)
+            {
+                if (string.Equals(arg, "-debug", StringComparison.OrdinalIgnoreCase))
+                {
+                    debug = true;
+                }
+                else if (string.Equals(arg, "-release", StringComparison.OrdinalIgnoreCase))
+                {
+                    debug = false;
+                }
+                else if (string.Equals(arg, "-nocache", StringComparison.OrdinalIgnoreCase))
+                {
+                    cache = false;
+                }
+            }
+
+            var baseDir = Directory.GetCurrentDirectory();
+            var field = typeof(Core).GetField("_BaseDirectory", BindingFlags.Static | BindingFlags.NonPublic);
+            field?.SetValue(null, baseDir);
+
+            Core.Assembly = typeof(Core).Assembly;
+
+            var success = ScriptCompiler.Compile(debug, cache);
+
+            return success ? 0 : 1;
+        }
+    }
+}

--- a/ScriptCompiler/ScriptCompiler.csproj
+++ b/ScriptCompiler/ScriptCompiler.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net48</TargetFramework>
+        <OutputType>Exe</OutputType>
+        <AssemblyName>ScriptCompiler</AssemblyName>
+        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+        <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+        <OutputPath>..\</OutputPath>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+        <OutputPath>..\</OutputPath>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\Server\Server.csproj" />
+    </ItemGroup>
+</Project>

--- a/ServUO.sln
+++ b/ServUO.sln
@@ -26,6 +26,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Scripts", "Scripts\Scripts.
 		{AE4A9EAA-E0EB-4DC9-9604-BE4289F9F6C3} = {AE4A9EAA-E0EB-4DC9-9604-BE4289F9F6C3}
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ScriptCompiler", "ScriptCompiler\ScriptCompiler.csproj", "{6AFA1198-783A-4DAD-824F-720FF9EE59E2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -44,6 +46,10 @@ Global
 		{308EA7C6-2873-4E47-AF3F-ABBA3F8AB63E}.Debug|x64.Build.0 = Debug|x64
 		{308EA7C6-2873-4E47-AF3F-ABBA3F8AB63E}.Release|x64.ActiveCfg = Release|x64
 		{308EA7C6-2873-4E47-AF3F-ABBA3F8AB63E}.Release|x64.Build.0 = Release|x64
+		{6AFA1198-783A-4DAD-824F-720FF9EE59E2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6AFA1198-783A-4DAD-824F-720FF9EE59E2}.Debug|x64.Build.0 = Debug|Any CPU
+		{6AFA1198-783A-4DAD-824F-720FF9EE59E2}.Release|x64.ActiveCfg = Release|Any CPU
+		{6AFA1198-783A-4DAD-824F-720FF9EE59E2}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- add new `ScriptCompiler` project providing a command-line tool to compile Scripts
- wire the new tool into the solution for separate script compilation

## Testing
- `dotnet build ServUO.sln -c Debug -p:Platform=x64` *(fails: The imported project "/usr/lib/dotnet/sdk/8.0.119/Sdks/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets" was not found)*
- `dotnet build ScriptCompiler/ScriptCompiler.csproj -c Debug -p:Platform=x64`

------
https://chatgpt.com/codex/tasks/task_e_68ab5513f110832992b0fd1f90e53180